### PR TITLE
Error when calling runSeuratClustering

### DIFF
--- a/R/runA-Z.R
+++ b/R/runA-Z.R
@@ -1746,8 +1746,8 @@ runSeuratClustering <- function(object,
 
   confuns::check_none_of(
     input = name,
-    against = getVariableNames(object),
-    ref.against = "known variables"
+    against = getFeatureNames(object),
+    ref.against = "feature names",
   )
 
   cluster_df <-


### PR DESCRIPTION
getVariableNames is not a method on SPATA2 object - I think the correct one is getFeatureNames.

Before:
```
No such method getVariableNames
```

After:
```
14:34:40 Using matrix 'scaled'.
14:34:40 Using expression matrix 'scaled'.
Calculating gene variances
0%   10   20   30   40   50   60   70   80   90   100%
[----|----|----|----|----|----|----|----|----|----|
**************************************************|
Calculating feature variances of standardized and clipped values
0%   10   20   30   40   50   60   70   80   90   100%
[----|----|----|----|----|----|----|----|----|----|
**************************************************|
...
```